### PR TITLE
Add origin-based endpoints

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -32,6 +32,12 @@ type HierarchyClient interface {
 	GetCompany(ctx context.Context, id uuid.UUID) (models.Node, error)
 	GetSubtree(ctx context.Context, id uuid.UUID, filter TreeFilter) ([]models.Node, error)
 	GetSubtreeCount(ctx context.Context, id uuid.UUID, nodeTypes ...string) (int64, error)
+
+	GetOrigins(ctx context.Context, provider string) ([]models.Origin, error)
+	GetOriginsByType(ctx context.Context, provider, originType string) ([]models.Origin, error)
+	GetProviderNodeIDs(ctx context.Context, provider string) ([]uuid.UUID, error)
+	GetProviderNodeIDsByType(ctx context.Context, provider, originType string) ([]uuid.UUID, error)
+	GetOriginNodeID(ctx context.Context, origin models.Origin) (uuid.UUID, error)
 }
 
 type client struct {
@@ -180,4 +186,85 @@ func (c *client) GetSubtreeCount(ctx context.Context, id uuid.UUID, nodeTypes ..
 	}
 
 	return response.NodeCount, nil
+}
+
+func (c *client) GetOrigins(ctx context.Context, provider string) ([]models.Origin, error) {
+	request := rest.Get("origin/{provider}").
+		Assign("provider", provider).
+		SetHeader("Accept", "application/json")
+
+	var response models.WebmodelsOrigins
+	if err := c.DoAndUnmarshal(ctx, request, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Origins, nil
+}
+
+func (c *client) GetOriginsByType(ctx context.Context, provider, originType string) ([]models.Origin, error) {
+	request := rest.Get("origin/{provider}/{type}").
+		Assign("provider", provider).
+		Assign("type", originType).
+		SetHeader("Accept", "application/json")
+
+	var response models.WebmodelsOrigins
+	if err := c.DoAndUnmarshal(ctx, request, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Origins, nil
+}
+
+func (c *client) GetProviderNodeIDs(ctx context.Context, provider string) ([]uuid.UUID, error) {
+	request := rest.Get("origin/{provider}/nodes").
+		Assign("provider", provider).
+		SetHeader("Accept", "application/json")
+
+	var response models.WebmodelsNodeIDs
+	if err := c.DoAndUnmarshal(ctx, request, &response); err != nil {
+		return nil, err
+	}
+
+	// Hierarchy swagger does not tell the model generator that it is an array of UUIDs
+	nodeIDs := make([]uuid.UUID, len(response.NodeIds))
+	for _, s := range response.NodeIds {
+		nodeIDs = append(nodeIDs, uuid.UUID(s))
+	}
+
+	return nodeIDs, nil
+}
+
+func (c *client) GetProviderNodeIDsByType(ctx context.Context, provider, originType string) ([]uuid.UUID, error) {
+	request := rest.Get("origin/{provider}/{type}/nodes").
+		Assign("provider", provider).
+		Assign("type", originType).
+		SetHeader("Accept", "application/json")
+
+	var response models.WebmodelsNodeIDs
+	if err := c.DoAndUnmarshal(ctx, request, &response); err != nil {
+		return nil, err
+	}
+
+	// Hierarchy swagger does not tell the model generator that it is an array of UUIDs
+	nodeIDs := make([]uuid.UUID, len(response.NodeIds))
+	for _, s := range response.NodeIds {
+		nodeIDs = append(nodeIDs, uuid.UUID(s))
+	}
+
+	return nodeIDs, nil
+}
+
+func (c *client) GetOriginNodeID(ctx context.Context, origin models.Origin) (uuid.UUID, error) {
+	request := rest.Get("origin/{provider}/{type}/{id}/nodes").
+		Assign("provider", origin.Provider).
+		Assign("type", origin.Type).
+		Assign("id", origin.ID).
+		SetHeader("Accept", "application/json")
+
+	var response models.WebmodelsNodeID
+	if err := c.DoAndUnmarshal(ctx, request, &response); err != nil {
+		return uuid.EmptyUUID, err
+	}
+
+	return response.NodeID, nil
 }

--- a/rest/client.go
+++ b/rest/client.go
@@ -71,7 +71,7 @@ func (c *client) GetNode(ctx context.Context, id uuid.UUID) (models.Node, error)
 }
 
 func (c *client) CreateNode(ctx context.Context, node models.WebmodelsNodeInput) (uuid.UUID, error) {
-	request := rest.Put("nodes").
+	request := rest.Post("nodes").
 		WithJSONPayload(node).
 		SetHeader("Accept", "application/json")
 
@@ -84,7 +84,7 @@ func (c *client) CreateNode(ctx context.Context, node models.WebmodelsNodeInput)
 }
 
 func (c *client) UpdateNode(ctx context.Context, id uuid.UUID, node models.WebmodelsNodeInput) (models.Node, error) {
-	request := rest.Post("nodes/{node}").
+	request := rest.Put("nodes/{node}").
 		Assign("node", id).
 		WithJSONPayload(node).
 		SetHeader("Accept", "application/json")

--- a/rest/mock/client.go
+++ b/rest/mock/client.go
@@ -69,3 +69,28 @@ func (c *HierarchyClientMock) GetSubtreeCount(ctx context.Context, id uuid.UUID,
 	args := c.Called(ctx, id, nodeTypes)
 	return args.Get(0).(int64), args.Error(1)
 }
+
+func (c *HierarchyClientMock) GetOrigins(ctx context.Context, provider string) ([]models.Origin, error) {
+	args := c.Called(ctx, provider)
+	return args.Get(0).([]models.Origin), args.Error(1)
+}
+
+func (c *HierarchyClientMock) GetOriginsByType(ctx context.Context, provider, originType string) ([]models.Origin, error) {
+	args := c.Called(ctx, provider, originType)
+	return args.Get(0).([]models.Origin), args.Error(1)
+}
+
+func (c *HierarchyClientMock) GetProviderNodeIDs(ctx context.Context, provider string) ([]uuid.UUID, error) {
+	args := c.Called(ctx, provider)
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
+func (c *HierarchyClientMock) GetProviderNodeIDsByType(ctx context.Context, provider, originType string) ([]uuid.UUID, error) {
+	args := c.Called(ctx, provider, originType)
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
+func (c *HierarchyClientMock) GetOriginNodeID(ctx context.Context, origin models.Origin) (uuid.UUID, error) {
+	args := c.Called(ctx, origin)
+	return args.Get(0).(uuid.UUID), args.Error(1)
+}

--- a/rest/swagger.json
+++ b/rest/swagger.json
@@ -2114,7 +2114,8 @@
           "type": "string",
           "example": "TREEELEM"
         }
-      }
+      },
+      "x-nullable": false
     },
     "webmodels.AssetClasses": {
       "type": "object",

--- a/scripts/patch-x-nullable.sh
+++ b/scripts/patch-x-nullable.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
-OUTPUT=$(jq '.definitions.Node["x-nullable"] = false' $1)
+OUTPUT=$(
+  cat "$1" \
+  | jq '.definitions.Node["x-nullable"] = false' \
+  | jq '.definitions.Origin["x-nullable"] = false' \
+)
 
 [[ $? == 0 ]] && echo "${OUTPUT}" >| $1


### PR DESCRIPTION
This PR adds all origin based endpoints from Hierarchy.

https://api.sandbox.hierarchy.enlight.skf.com/swagger/index.html#/Origin

This PR also includes a bug fix for creating/updating nodes.