### PR TITLE
Revert change to swagger to enable non-nullable origins

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -198,7 +198,16 @@ func (c *client) GetOrigins(ctx context.Context, provider string) ([]models.Orig
 		return nil, err
 	}
 
-	return response.Origins, nil
+	origins := make([]models.Origin, 0, len(response.Origins))
+
+	// Dereference all possible null values from response
+	for _, origin := range response.Origins {
+		if origin != nil {
+			origins = append(origins, *origin)
+		}
+	}
+
+	return origins, nil
 }
 
 func (c *client) GetOriginsByType(ctx context.Context, provider, originType string) ([]models.Origin, error) {
@@ -212,7 +221,16 @@ func (c *client) GetOriginsByType(ctx context.Context, provider, originType stri
 		return nil, err
 	}
 
-	return response.Origins, nil
+	origins := make([]models.Origin, 0, len(response.Origins))
+
+	// Dereference all possible null values from response
+	for _, origin := range response.Origins {
+		if origin != nil {
+			origins = append(origins, *origin)
+		}
+	}
+
+	return origins, nil
 }
 
 func (c *client) GetProviderNodeIDs(ctx context.Context, provider string) ([]uuid.UUID, error) {

--- a/rest/swagger.json
+++ b/rest/swagger.json
@@ -2114,8 +2114,7 @@
           "type": "string",
           "example": "TREEELEM"
         }
-      },
-      "x-nullable": false
+      }
     },
     "webmodels.AssetClasses": {
       "type": "object",

--- a/scripts/patch-x-nullable.sh
+++ b/scripts/patch-x-nullable.sh
@@ -3,7 +3,6 @@
 OUTPUT=$(
   cat "$1" \
   | jq '.definitions.Node["x-nullable"] = false' \
-  | jq '.definitions.Origin["x-nullable"] = false' \
 )
 
 [[ $? == 0 ]] && echo "${OUTPUT}" >| $1


### PR DESCRIPTION
Last PR (#2) made Origin model non-nullable which broke the input model for creating nodes where the Origin might be null.